### PR TITLE
fix: reconfigure image and links for local gh docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/upstateinteractive/docs/blob/master/files/sm-grad-logo.png" >
+<img src="https://github.com/upstateinteractive/docs/blob/master/files/sm-grad-logo.png?raw=true" >
 
 # Contributing to UI Docs
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<img src="../../files/sm-grad-logo.png" >
+<img src="https://github.com/upstateinteractive/docs/blob/master/files/sm-grad-logo.png" >
 
 # Contributing to UI Docs
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<img src="../files/sm-grad-logo.png" >
+<img src="https://github.com/upstateinteractive/docs/blob/master/files/sm-grad-logo.png" >
 
 # Upstate Interactive Docs
 
@@ -18,7 +18,7 @@
 
 > Please fill out before merging.
 
-- [ ] I have read [CONTRIBUTING.md](./CONTRIBUTING.md).
+- [ ] I have read [CONTRIBUTING.md](https://github.com/upstateinteractive/docs/blob/master/.github/CONTRIBUTING.md).
 
 ## Additional Comments
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/upstateinteractive/docs/blob/master/files/sm-grad-logo.png" >
+<img src="https://github.com/upstateinteractive/docs/blob/master/files/sm-grad-logo.png?raw=true" >
 
 # Upstate Interactive Docs
 


### PR DESCRIPTION
<img src="https://github.com/upstateinteractive/docs/blob/master/files/sm-grad-logo.png?raw=true" >

# Upstate Interactive Docs

## Types of Changes

> What types of changes does your code introduce? _Check all that apply._

- [x] update / refactor
- [ ] new feature / technology
- [ ] documentation

## Relevant Issues / Pull Requests

> What issues or pull requests are related to this pull request?

N/A

## Checklist

> Please fill out before merging.

- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md).

## Additional Comments

> Anything else we should know?

This should resolve the linking issues in the previous GH documentation.